### PR TITLE
Drop ffmpeg extension

### DIFF
--- a/eu.nokun.MirrorHall.json
+++ b/eu.nokun.MirrorHall.json
@@ -5,6 +5,7 @@
     "sdk": "org.gnome.Sdk",
     "command": "mirrorhall",
     "finish-args": [
+        "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/codecs-extra/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0",
         "--share=network",
         "--share=ipc",
         "--device=dri",

--- a/eu.nokun.MirrorHall.json
+++ b/eu.nokun.MirrorHall.json
@@ -5,7 +5,6 @@
     "sdk": "org.gnome.Sdk",
     "command": "mirrorhall",
     "finish-args": [
-        "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/codecs-extra/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0",
         "--share=network",
         "--share=ipc",
         "--device=dri",

--- a/eu.nokun.MirrorHall.json
+++ b/eu.nokun.MirrorHall.json
@@ -3,13 +3,6 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "49",
     "add-extensions": {
-        "org.freedesktop.Platform.ffmpeg-full": {
-            "version": "25.08",
-            "directory": "lib/ffmpeg",
-            "add-ld-path": ".",
-            "no-autodownload": false,
-            "autodelete": false
-        },
         "org.freedesktop.Platform.GStreamer.gstreamer-vaapi": {
             "directory": "lib/gstreamer-1.0",
             "version": "25.08",
@@ -44,7 +37,7 @@
         "*.a"
     ],
     "cleanup-commands": [
-        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg ${FLATPAK_DEST}/lib/gstreamer-1.0"
+        "mkdir -p ${FLATPAK_DEST}/lib/gstreamer-1.0"
     ],
     "modules": [
         "python3-requirements.json",

--- a/eu.nokun.MirrorHall.json
+++ b/eu.nokun.MirrorHall.json
@@ -2,17 +2,6 @@
     "app-id": "eu.nokun.MirrorHall",
     "runtime": "org.gnome.Platform",
     "runtime-version": "49",
-    "add-extensions": {
-        "org.freedesktop.Platform.GStreamer.gstreamer-vaapi": {
-            "directory": "lib/gstreamer-1.0",
-            "version": "25.08",
-            "autodelete": false,
-            "no-autodownload": true,
-            "add-ld-path": "lib",
-            "download-if": "have-intel-gpu",
-            "autoprune-unless": "have-intel-gpu"
-        }
-    },
     "sdk": "org.gnome.Sdk",
     "command": "mirrorhall",
     "finish-args": [
@@ -35,9 +24,6 @@
         "/share/pkgconfig",
         "*.la",
         "*.a"
-    ],
-    "cleanup-commands": [
-        "mkdir -p ${FLATPAK_DEST}/lib/gstreamer-1.0"
     ],
     "modules": [
         "python3-requirements.json",


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10, and 5.15-25.08) provides FFMPEG; therefore, declaring **org.freedesktop.Platform.ffmpeg-full** extension is no longer required.

> in the manifest. org.freedesktop.Platform.codecs-extra will be automatically installed by the runtime and will be available to users.

More information

- https://bbhtt.in/posts/closing-the-chapter-on-openh264/
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1825
- https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/931


Fixes: https://github.com/flathub/eu.nokun.MirrorHall/issues/6
Fixes: https://github.com/flathub/eu.nokun.MirrorHall/issues/8