### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/eu.nokun.MirrorHall.json
+++ b/eu.nokun.MirrorHall.json
@@ -10,7 +10,7 @@
         "--device=dri",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--talk-name=org.gnome.Mutter.ScreenCast",
         "--env=GST_DEBUG=2"
     ],


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7